### PR TITLE
simplejson removed from Django, now used directly from Python

### DIFF
--- a/jsonate/fields.py
+++ b/jsonate/fields.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils import simplejson as json
+import simplejson as json
 from jsonate.utils import jsonate
 from jsonate.widgets import JsonateWidget
 from jsonate.form_fields import JsonateFormField

--- a/jsonate/form_fields.py
+++ b/jsonate/form_fields.py
@@ -1,6 +1,6 @@
 from django.forms import CharField, ValidationError
 from jsonate.widgets import JsonateWidget
-from django.utils import simplejson as json
+import simplejson as json
 
  
 def JsonateValidator(value):

--- a/jsonate/json_encoder.py
+++ b/jsonate/json_encoder.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from decimal import Decimal
-from django.utils import simplejson as json
+import simplejson as json
 from django.db.models.query import QuerySet, ValuesQuerySet
 from django.db.models import Model
 from django.db.models.fields.related import ForeignKey

--- a/jsonate/utils.py
+++ b/jsonate/utils.py
@@ -1,4 +1,4 @@
-from django.utils import simplejson as json
+import simplejson as json
      
 from jsonate.json_encoder import JsonateEncoder
 

--- a/jsonate/widgets.py
+++ b/jsonate/widgets.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils import simplejson as json
+import simplejson as json
 from jsonate.utils import jsonate
 
 class JsonateWidget(forms.Textarea):


### PR DESCRIPTION
Just did this upgrade to meet basic 1.7 requirements.

Tests still not running well under 1.7
