### PR TITLE
Setup.py need long_description content_type declared now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     
     description=('Django library that can make ANYTHING into json'),
     long_description=open('README.markdown').read(),
+    long_description_content_type="text/markdown",
     
     license='MIT',
     keywords='django json templatetags',


### PR DESCRIPTION
pypi needs long_description content type declared now, if it is not rst